### PR TITLE
Enable multiple deepl config support

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 function createContextMenus() {
 	chrome.contextMenus.removeAll(() => {
 		chrome.storage.sync.get(
-			["wiktionaryEnabled", "deeplEnabled", "sourceLanguage", "targetLanguage"],
+			["wiktionaryEnabled", "deeplEnabled", "deeplConfigurations"],
 			(data) => {
 				if (data.wiktionaryEnabled ?? true) {
 					chrome.contextMenus.create({
@@ -11,13 +11,15 @@ function createContextMenus() {
 					});
 				}
 				if (data.deeplEnabled ?? true) {
-					const sourceLang = data.sourceLanguage || "de";
-					const targetLang = data.targetLanguage || "en";
+					const deeplConfigurations = data.deeplConfigurations || [];
 
-					chrome.contextMenus.create({
-						id: "deeplTranslate",
-						title: `Translate with DeepL (${sourceLang.toUpperCase()} → ${targetLang.toUpperCase()})`,
-						contexts: ["selection"],
+					console.log(deeplConfigurations);
+					deeplConfigurations.forEach((pair) => {
+						chrome.contextMenus.create({
+							id: `deeplTranslate-${pair.source}-${pair.target}`,
+							title: `Translate with DeepL (${pair.source.toUpperCase()} → ${pair.target.toUpperCase()})`,
+							contexts: ["selection"],
+						});
 					});
 				}
 			}

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 		<label>
 			<input type="checkbox" id="deeplToggle" /> Enable DeepL Translation
 		</label>
-		<h2>Translation Pairs</h2>
+		<h2>DeepL Configurations</h2>
 		<div id="deeplConfigContainer"></div>
 		<button id="addConfig">Add Configuration</button>
 		<br /><br />

--- a/options.html
+++ b/options.html
@@ -1,29 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <title>Extension Options</title>
-</head>
-<body>
-    <h2>Context Menu Options</h2>
-    <label>
-        <input type="checkbox" id="wiktionaryToggle"> Enable Wiktionary Search
-    </label>
-    <br>
-    <label>
-        <input type="checkbox" id="deeplToggle"> Enable DeepL Translation
-    </label>
-    <br><br>
-    <label>
-        <strong>Select source language:</strong>
-        <select id="sourceLanguage"></select>
-    </label>
-    <br><br>
-    <label>
-        <strong>Select target language:</strong>
-        <select id="targetLanguage"></select>
-    </label>
-    <br><br>
-    <button id="save">Save</button>
-    <script src="options.js" type="module"></script>
-</body>
+	<head>
+		<title>Extension Options</title>
+	</head>
+	<body>
+		<h2>Context Menu Options</h2>
+		<label>
+			<input type="checkbox" id="wiktionaryToggle" /> Enable Wiktionary Search
+		</label>
+		<br />
+		<label>
+			<input type="checkbox" id="deeplToggle" /> Enable DeepL Translation
+		</label>
+		<h2>Translation Pairs</h2>
+		<div id="deeplConfigContainer"></div>
+		<button id="addConfig">Add Configuration</button>
+		<br /><br />
+		<br /><br />
+		<button id="save">Save</button>
+		<script src="options.js" type="module"></script>
+	</body>
 </html>

--- a/options.js
+++ b/options.js
@@ -2,44 +2,93 @@ import { sourceLanguageList, targetLanguageList } from "./deepl-languages.js";
 
 const wiktionaryToggle = document.getElementById("wiktionaryToggle");
 const deeplToggle = document.getElementById("deeplToggle");
-const sourceLanguageSelect = document.getElementById("sourceLanguage");
-const targetLanguageSelect = document.getElementById("targetLanguage");
+const addConfigButton = document.getElementById("addConfig");
+const deeplConfigContainer = document.getElementById("deeplConfigContainer");
 const saveButton = document.getElementById("save");
-
-// Populate dropdowns with language options
-sourceLanguageList.forEach((lang) => {
-	const optionSource = document.createElement("option");
-	optionSource.value = lang.displayNameShortLanguage;
-	optionSource.text = lang.displayName;
-	sourceLanguageSelect.appendChild(optionSource);
-});
-
-targetLanguageList.forEach((lang) => {
-	const optionTarget = document.createElement("option");
-	optionTarget.value = lang.displayNameShortLanguage;
-	optionTarget.text = lang.displayName;
-	targetLanguageSelect.appendChild(optionTarget);
-});
 
 // Load saved selections from chrome.storage
 chrome.storage.sync.get(
-	["wiktionaryEnabled", "deeplEnabled", "sourceLanguage", "targetLanguage"],
+	["wiktionaryEnabled", "deeplEnabled", "deeplConfigurations"],
 	(data) => {
 		wiktionaryToggle.checked = data.wiktionaryEnabled ?? true;
 		deeplToggle.checked = data.deeplEnabled ?? true;
-		sourceLanguageSelect.value = data.sourceLanguage || "de";
-		targetLanguageSelect.value = data.targetLanguage || "en";
+
+		const pairs = data.deeplConfigurations ?? [{ source: "de", target: "en" }];
+		pairs.forEach((pair) => createTranslationPair(pair.source, pair.target));
 	}
 );
 
+function createLanguageOptionElement(langList, selectedValue) {
+	const select = document.createElement("select");
+	langList.forEach((lang) => {
+		const option = document.createElement("option");
+		option.value = lang.displayNameShortLanguage;
+		option.textContent = lang.displayName;
+		if (lang.displayNameShortLanguage === selectedValue) {
+			option.selected = true;
+		}
+		select.appendChild(option);
+	});
+	return select;
+}
+
+function createTranslationPair(sourceLang = "de", targetLang = "en") {
+	const wrapper = document.createElement("div");
+	wrapper.className = "translation-pair";
+
+	const sourceLabel = document.createElement("label");
+	sourceLabel.textContent = "Source: ";
+	const sourceSelect = createLanguageOptionElement(
+		sourceLanguageList,
+		sourceLang
+	);
+	sourceSelect.className = "sourceLanguage";
+	sourceLabel.appendChild(sourceSelect);
+
+	const targetLabel = document.createElement("label");
+	targetLabel.textContent = " Target: ";
+	const targetSelect = createLanguageOptionElement(
+		targetLanguageList,
+		targetLang
+	);
+	targetSelect.className = "targetLanguage";
+	targetLabel.appendChild(targetSelect);
+
+	const removeButton = document.createElement("button");
+	removeButton.textContent = "Remove";
+	removeButton.className = "removePair";
+	removeButton.addEventListener("click", () => {
+		deeplConfigContainer.removeChild(wrapper);
+	});
+
+	wrapper.appendChild(sourceLabel);
+	wrapper.appendChild(targetLabel);
+	wrapper.appendChild(removeButton);
+
+	deeplConfigContainer.appendChild(wrapper);
+}
+
+// Add a new row for deepl configurations
+addConfigButton.addEventListener("click", () => {
+	createTranslationPair();
+});
+
 // Save selected languages to chrome.storage
 saveButton.addEventListener("click", () => {
+	const pairElements =
+		deeplConfigContainer.getElementsByClassName("translation-pair");
+	const deeplConfigurations = Array.from(pairElements).map((el) => {
+		return {
+			source: el.querySelector(".sourceLanguage").value,
+			target: el.querySelector(".targetLanguage").value,
+		};
+	});
+
 	chrome.storage.sync.set(
 		{
 			wiktionaryEnabled: wiktionaryToggle.checked,
 			deeplEnabled: deeplToggle.checked,
-			sourceLanguage: sourceLanguageSelect.value,
-			targetLanguage: targetLanguageSelect.value,
+			deeplConfigurations: deeplConfigurations,
 		},
 		() => {
 			alert("Languages saved! Right-click menu will update.");


### PR DESCRIPTION
Closes #2 

This PR adds support for multiple deepl configurations in the plugin, and updates the options page to reflect this change.

Through the options page, rows of configurations can now be added and removed.

<img width="540" height="254" alt="image" src="https://github.com/user-attachments/assets/e2138097-4034-4e8c-a093-2aaf90ac767e" />
<img width="815" height="406" alt="image" src="https://github.com/user-attachments/assets/74d1ce7c-e234-42b2-9a09-299defa0eecf" />
